### PR TITLE
Add extensive attack detection rules

### DIFF
--- a/Backend/Config.py
+++ b/Backend/Config.py
@@ -7,5 +7,18 @@ EXCLUDED_IP_RANGES = [
     #"192.168.53."
 ]
 
+# Ranges used by the fictive "Denamysch" network which should
+# immediately be blocked when detected.
+DENAMYSCH_IP_RANGES = [
+    "203.0.113.",
+    "198.51.100."
+]
+
+# Thresholds for various detection rules
+PORT_SCAN_THRESHOLD = 10  # distinct ports within the time window
+PORT_SCAN_WINDOW = 5      # seconds
+BRUTE_FORCE_THRESHOLD = 5 # failed attempts within the time window
+BRUTE_FORCE_WINDOW = 60   # seconds
+
 SYN_FLOOD_PROTECTION_ENABLED = True
 SYN_FLOOD_TIMEOUT = 2

--- a/Backend/Module/Rules.py
+++ b/Backend/Module/Rules.py
@@ -1,43 +1,142 @@
 import json
+from datetime import datetime, timedelta
 from scapy.all import sniff, IP, TCP, UDP, send
-from datetime import datetime
-from Config import FORWARDING_RULES
+
+from Config import (
+    FORWARDING_RULES,
+    DENAMYSCH_IP_RANGES,
+    PORT_SCAN_THRESHOLD,
+    PORT_SCAN_WINDOW,
+    BRUTE_FORCE_THRESHOLD,
+    BRUTE_FORCE_WINDOW,
+)
 from Module.Manage_Connections import connection_manager
+from Module import Block
 
 
-def log_http_traffic(packet):
-    if packet["http"]:
-        print(f"HTTP traffic detected: {packet}")
+def log_http_traffic(pkt, entry):
+    """Simple logger for HTTP traffic"""
+    if entry.get("http"):
+        print(f"HTTP traffic detected: {entry}")
 
 
-def log_https_traffic(packet):
-    if packet["https"]:
-        print(f"HTTPS traffic detected: {packet}")
+def log_https_traffic(pkt, entry):
+    if entry.get("https"):
+        print(f"HTTPS traffic detected: {entry}")
 
 
-def forward_traffic(packet):
-    if packet["http"]:
+def forward_traffic(pkt, entry):
+    if entry.get("http"):
         new_port = FORWARDING_RULES.get("http")
-    elif packet["https"]:
+    elif entry.get("https"):
         new_port = FORWARDING_RULES.get("https")
     else:
         new_port = None
 
     if new_port:
-        ip_layer = IP(src=packet["ip_src"], dst=packet["ip_dst"])
-        if packet["proto"] == "TCP":
-            transport_layer = TCP(sport=packet["sport"], dport=new_port, flags='S')
-        elif packet["proto"] == "UDP":
-            transport_layer = UDP(sport=packet["sport"], dport=new_port)
+        ip_layer = IP(src=entry["ip_src"], dst=entry["ip_dst"])
+        if entry["proto"] == "TCP":
+            transport_layer = TCP(sport=entry["sport"], dport=new_port, flags='S')
+        elif entry["proto"] == "UDP":
+            transport_layer = UDP(sport=entry["sport"], dport=new_port)
 
-        new_packet = ip_layer / transport_layer / packet["payload"]
+        new_packet = ip_layer / transport_layer / entry["payload"]
         send(new_packet)
-        print(f"Forwarded traffic: {packet} to port {new_port}")
+        print(f"Forwarded traffic: {entry} to port {new_port}")
 
 
-def monitor_tcp_connections(packet):
-    if TCP in packet:
-        if packet[TCP].flags == 'S':  # SYN-Flag
-            connection_manager.add_connection(packet[IP].src, packet[TCP].sport, packet[IP].dst, packet[TCP].dport)
-        elif packet[TCP].flags == 'SA' or packet[TCP].flags == 'A':  # SYN-ACK or ACK-Flag
-            connection_manager.remove_connection(packet[IP].src, packet[TCP].sport, packet[IP].dst, packet[TCP].dport)
+def monitor_tcp_connections(pkt, entry):
+    """Track TCP handshakes to mitigate SYN flood attacks."""
+    if TCP in pkt:
+        if pkt[TCP].flags == 'S':  # SYN flag
+            connection_manager.add_connection(pkt[IP].src, pkt[TCP].sport, pkt[IP].dst, pkt[TCP].dport)
+        elif pkt[TCP].flags in ('SA', 'A'):  # SYN-ACK or ACK
+            connection_manager.remove_connection(pkt[IP].src, pkt[TCP].sport, pkt[IP].dst, pkt[TCP].dport)
+
+
+# ------------------------- Additional Detection Rules ------------------------
+
+# Tracking dictionaries for stateful detections
+_port_scan_history = {}
+_brute_force_history = {}
+
+
+def detect_denamysch_ip(pkt, entry):
+    """Block traffic coming from known Denamysch ranges."""
+    ip = entry.get("ip_src")
+    if not ip:
+        return
+    if any(ip.startswith(prefix) for prefix in DENAMYSCH_IP_RANGES):
+        Block.perma_block(ip, "Denamysch range")
+
+
+def detect_port_scan(pkt, entry):
+    ip = entry.get("ip_src")
+    port = entry.get("dport")
+    if not ip or port is None:
+        return
+    records = _port_scan_history.setdefault(ip, [])
+    records.append((port, datetime.now()))
+    cutoff = datetime.now() - timedelta(seconds=PORT_SCAN_WINDOW)
+    _port_scan_history[ip] = [(p, ts) for p, ts in records if ts > cutoff]
+    unique_ports = {p for p, _ in _port_scan_history.get(ip, [])}
+    if len(unique_ports) >= PORT_SCAN_THRESHOLD:
+        Block.temp_block(ip, 30, "Port scan detected")
+        _port_scan_history.pop(ip, None)
+
+
+def detect_sql_injection(pkt, entry):
+    payload = entry.get("payload", "").lower()
+    patterns = ["select", "union", " or ", "--", "' or", "drop table"]
+    if any(p in payload for p in patterns):
+        Block.temp_block(entry.get("ip_src"), 30, "SQL injection attempt")
+
+
+def detect_xss(pkt, entry):
+    payload = entry.get("payload", "").lower()
+    if "<script" in payload or "javascript:" in payload:
+        Block.temp_block(entry.get("ip_src"), 30, "XSS attempt")
+
+
+def detect_directory_traversal(pkt, entry):
+    payload = entry.get("payload", "")
+    if "../" in payload:
+        Block.temp_block(entry.get("ip_src"), 30, "Directory traversal attempt")
+
+
+def detect_bruteforce(pkt, entry):
+    ip = entry.get("ip_src")
+    payload = entry.get("payload", "")
+    if not ip or "POST /login" not in payload:
+        return
+    attempts = _brute_force_history.setdefault(ip, [])
+    attempts.append(datetime.now())
+    cutoff = datetime.now() - timedelta(seconds=BRUTE_FORCE_WINDOW)
+    _brute_force_history[ip] = [ts for ts in attempts if ts > cutoff]
+    if len(_brute_force_history.get(ip, [])) >= BRUTE_FORCE_THRESHOLD:
+        Block.temp_block(ip, 30, "Brute force login")
+        _brute_force_history.pop(ip, None)
+
+
+def detect_dns_amplification(pkt, entry):
+    if entry.get("proto") == "UDP" and entry.get("sport") == 53:
+        if len(entry.get("payload", b"")) > 512:
+            Block.temp_block(entry.get("ip_src"), 30, "DNS amplification")
+
+
+def detect_ntp_amplification(pkt, entry):
+    if entry.get("proto") == "UDP" and entry.get("sport") == 123:
+        if len(entry.get("payload", b"")) > 468:
+            Block.temp_block(entry.get("ip_src"), 30, "NTP amplification")
+
+
+def detect_suspicious_user_agent(pkt, entry):
+    payload = entry.get("payload", "").lower()
+    if "user-agent" in payload:
+        if any(tool in payload for tool in ["nmap", "sqlmap", "dirbuster"]):
+            Block.temp_block(entry.get("ip_src"), 30, "Suspicious user agent")
+
+
+def detect_large_payload(pkt, entry):
+    if len(entry.get("payload", b"")) > 2000:
+        Block.temp_block(entry.get("ip_src"), 30, "Large payload")

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -89,7 +89,7 @@ def packet_callback(packet):
     if log_entry["proto"] in ["TCP", "UDP"]:
         log_to_json(log_entry, logfile)
         for rule in rules:
-            rule(log_entry)
+            rule(packet, log_entry)
 
 def log_resource_usage():
     resource_usage = {
@@ -119,6 +119,16 @@ def log_connections():
 register_rule(Rules.log_http_traffic)
 register_rule(Rules.log_https_traffic)
 register_rule(Rules.forward_traffic)
+register_rule(Rules.detect_denamysch_ip)
+register_rule(Rules.detect_port_scan)
+register_rule(Rules.detect_sql_injection)
+register_rule(Rules.detect_xss)
+register_rule(Rules.detect_directory_traversal)
+register_rule(Rules.detect_bruteforce)
+register_rule(Rules.detect_dns_amplification)
+register_rule(Rules.detect_ntp_amplification)
+register_rule(Rules.detect_suspicious_user_agent)
+register_rule(Rules.detect_large_payload)
 
 if SYN_FLOOD_PROTECTION_ENABLED:
     register_rule(Rules.monitor_tcp_connections)


### PR DESCRIPTION
## Summary
- configure Denamysch IP ranges and thresholds
- refactor Rules functions to accept packet and log entry
- add multiple detection rules such as port-scan and SQL injection
- register new rules in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b255876ac83259a2fd894aca881ce