### PR TITLE
Add backend test suite

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,33 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Backend"))
+from fastapi.testclient import TestClient
+from Module.API.API import app, read_json_file
+from unittest.mock import patch
+import Module.API.API as api
+
+client = TestClient(app)
+
+
+def test_read_json_file_missing(tmp_path):
+    file = tmp_path / "missing.json"
+    assert read_json_file(file) == []
+
+
+def test_logs_endpoint():
+    with patch('Module.API.API.read_json_file', return_value=[{"ok": True}]):
+        response = client.get('/logs/blocks')
+        assert response.status_code == 200
+        assert response.json() == [{"ok": True}]
+
+
+def test_resource_usage_endpoint():
+    with patch('Module.API.API.ResourceManager.get_cpu_usage', return_value=1), \
+         patch('Module.API.API.ResourceManager.get_ram_usage', return_value=2), \
+         patch('Module.API.API.ResourceManager.get_network_traffic', return_value={'bytes_sent':3,'bytes_received':4}):
+        response = client.get('/resource/usage')
+        assert response.status_code == 200
+        assert response.json() == {
+            'cpu_usage': 1,
+            'ram_usage': 2,
+            'network_traffic': {'bytes_sent':3,'bytes_received':4}
+        }

--- a/tests/test_manage_connections.py
+++ b/tests/test_manage_connections.py
@@ -1,0 +1,40 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Backend"))
+import importlib
+from unittest.mock import patch
+
+
+def load_module_without_thread(tmp_path):
+    sys.modules.pop('Module.Manage_Connections', None)
+    logs_dir = tmp_path / "Logs"
+    logs_dir.mkdir()
+    (logs_dir / "active_connections.json").write_text("[]")
+    with patch('threading.Thread.start', lambda self: None):
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            mod = importlib.import_module('Module.Manage_Connections')
+            mod.ConnectionManager.write_to_json = lambda self: None
+            return mod
+        finally:
+            os.chdir(cwd)
+
+
+def test_add_and_remove_connection(tmp_path):
+    mc = load_module_without_thread(tmp_path)
+    file = tmp_path / 'conns.json'
+    manager = mc.ConnectionManager(timeout=1, active_connections_file=str(file))
+    manager.add_connection('1.1.1.1', 1000, '2.2.2.2', 80)
+    assert ('1.1.1.1', 1000, '2.2.2.2', 80) in manager.connections
+    manager.remove_connection('1.1.1.1', 1000, '2.2.2.2', 80)
+    assert not manager.connections
+
+
+def test_close_connection_sends_rst(tmp_path):
+    mc = load_module_without_thread(tmp_path)
+    file = tmp_path / 'conns.json'
+    manager = mc.ConnectionManager(timeout=1, active_connections_file=str(file))
+    with patch.object(mc, 'send') as send_mock:
+        manager.close_connection('1.1.1.1', 1000, '2.2.2.2', 80)
+        send_mock.assert_called_once()

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -1,0 +1,24 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Backend"))
+import Module.ResourceManager as rm
+
+
+def test_cpu_usage_range():
+    usage = rm.ResourceManager.get_cpu_usage()
+    assert isinstance(usage, (int, float))
+    assert 0 <= usage <= 100
+
+
+def test_ram_usage_range():
+    usage = rm.ResourceManager.get_ram_usage()
+    assert isinstance(usage, (int, float))
+    assert 0 <= usage <= 100
+
+
+def test_network_traffic_keys():
+    data = rm.ResourceManager.get_network_traffic()
+    assert 'bytes_sent' in data and 'bytes_received' in data
+    assert isinstance(data['bytes_sent'], int)
+    assert isinstance(data['bytes_received'], int)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,54 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Backend"))
+from unittest.mock import patch
+import importlib
+
+def import_rules(tmp_path):
+    logs_dir = tmp_path / "Logs"
+    logs_dir.mkdir()
+    (logs_dir / "active_connections.json").write_text("[]")
+    with patch('threading.Thread.start', lambda self: None):
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            if 'Module.Rules' in sys.modules:
+                del sys.modules['Module.Rules']
+            if 'Module.Manage_Connections' in sys.modules:
+                del sys.modules['Module.Manage_Connections']
+            return importlib.import_module('Module.Rules')
+        finally:
+            os.chdir(cwd)
+
+
+def test_detect_denamysch_ip_blocks(tmp_path):
+    Rules = import_rules(tmp_path)
+    entry = {'ip_src': '203.0.113.5'}
+    with patch('Module.Rules.Block.perma_block') as pb:
+        Rules.detect_denamysch_ip(None, entry)
+        pb.assert_called_once_with('203.0.113.5', 'Denamysch range')
+
+
+def test_detect_sql_injection(tmp_path):
+    Rules = import_rules(tmp_path)
+    entry = {'ip_src': '1.2.3.4', 'payload': 'SELECT * FROM users'}
+    with patch('Module.Rules.Block.temp_block') as tb:
+        Rules.detect_sql_injection(None, entry)
+        tb.assert_called_once()
+
+
+def test_detect_xss(tmp_path):
+    Rules = import_rules(tmp_path)
+    entry = {'ip_src': '1.2.3.4', 'payload': '<script>alert(1)</script>'}
+    with patch('Module.Rules.Block.temp_block') as tb:
+        Rules.detect_xss(None, entry)
+        tb.assert_called_once()
+
+
+def test_detect_bruteforce(monkeypatch, tmp_path):
+    Rules = import_rules(tmp_path)
+    entry = {'ip_src': '1.1.1.1', 'payload': 'POST /login'}
+    monkeypatch.setattr(Rules, 'BRUTE_FORCE_THRESHOLD', 2)
+    with patch('Module.Rules.Block.temp_block') as tb:
+        Rules.detect_bruteforce(None, entry)
+        Rules.detect_bruteforce(None, entry)
+        tb.assert_called_once()


### PR DESCRIPTION
## Summary
- add pytest-based tests covering ResourceManager, API, detection rules and connection manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd6847e6883259390e77a124bacf8