### PR TITLE
Fix install script path for Config.py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if [[ "$choice" == "a" || "$choice" == "b" ]]; then
     read apply_settings
 
     if [[ "$apply_settings" == "yes" ]]; then
-        cat <<EOL > Backend/config.py
+        cat <<EOL > Backend/Config.py
 FORWARDING_RULES = {
 
 }
@@ -57,7 +57,7 @@ SYN_FLOOD_PROTECTION_ENABLED = True
 SYN_FLOOD_TIMEOUT = 2
 EOL
     else
-        cat <<EOL > Backend/config.py
+        cat <<EOL > Backend/Config.py
 FORWARDING_RULES = {
 
 }


### PR DESCRIPTION
## Summary
- ensure installer writes configuration to `Backend/Config.py`

## Testing
- `pip install scapy psutil fastapi uvicorn httpx`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdf907b38832596ffadf38b53c6d3