### PR TITLE
Ignore dashboard env file and document variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 dashboard/node_modules/
 dashboard/.next/
 .dashboard/.next/
+# Dashboard environment
+dashboard/.env

--- a/dashboard/.env
+++ b/dashboard/.env
@@ -1,4 +1,0 @@
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=adminpassword
-NEXTAUTH_SECRET=your_secret_key
-NEXTAUTH_URL=http://localhost:3000

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for the dashboard
+# Copy this file to `.env` and adjust the values as needed
+ADMIN_USERNAME=
+ADMIN_PASSWORD=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3000

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Environment Variables
+
+Create a `.env` file in the `dashboard` directory based on `.env.example`.
+The following variables are required:
+
+- `ADMIN_USERNAME` – username for the admin account
+- `ADMIN_PASSWORD` – password for the admin account
+- `NEXTAUTH_SECRET` – secret used to sign authentication tokens
+- `NEXTAUTH_URL` – URL of the Next.js application (default `http://localhost:3000`)
+


### PR DESCRIPTION
## Summary
- remove tracked `dashboard/.env`
- add `dashboard/.env` to `.gitignore`
- provide `.env.example` for the dashboard
- document required variables in `dashboard/README.md`

## Testing
- `pip install -r Backend/install.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdf9d7bf08325b68e5592ca4cd24a