### PR TITLE
Implement log rotation

### DIFF
--- a/Backend/Config.py
+++ b/Backend/Config.py
@@ -24,3 +24,6 @@ SYN_FLOOD_PROTECTION_ENABLED = True
 SYN_FLOOD_TIMEOUT = 2
 
 TC_INTERFACE = "eth0"
+
+# Maximum number of log records to keep when truncating log files
+MAX_LOG_RECORDS = 1000

--- a/Backend/Module/Block.py
+++ b/Backend/Module/Block.py
@@ -33,6 +33,9 @@ def read_from_json(file):
 def log_measure(measure):
     logs = read_from_json(block_log_file)
     logs.append(measure)
+    from Config import MAX_LOG_RECORDS
+    if len(logs) > MAX_LOG_RECORDS:
+        logs = logs[-MAX_LOG_RECORDS:]
     write_to_json(block_log_file, logs)
 
 def update_active_measures(measure):

--- a/Backend/Module/Manage_Connections.py
+++ b/Backend/Module/Manage_Connections.py
@@ -31,6 +31,9 @@ class ConnectionManager:
                 }
                 for conn, timestamp in self.connections.items()
             ]
+            from Config import MAX_LOG_RECORDS
+            if len(connections_list) > MAX_LOG_RECORDS:
+                connections_list = connections_list[-MAX_LOG_RECORDS:]
             with open(self.active_connections_file, 'w') as f:
                 json.dump(connections_list, f, indent=4)
 

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -52,6 +52,10 @@ def log_to_json(data, file):
             except json.JSONDecodeError:
                 logs = []
             logs.append(data)
+            # Truncate the list when it exceeds the configured size
+            from Config import MAX_LOG_RECORDS
+            if len(logs) > MAX_LOG_RECORDS:
+                logs = logs[-MAX_LOG_RECORDS:]
             f.seek(0)
             json.dump(logs, f, indent=4)
     logger.debug("Successfully wrote data to %s", file)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Dieses Projekt bietet eine robuste Lösung zur Überwachung und Verwaltung von N
 - **GET** `/logs/network`: Abrufen der protokollierten Netzwerkdaten.
 - **GET** `/logs/resource`: Abrufen der protokollierten Ressourcennutzungsdaten.
 
+## Log-Verwaltung
+
+Um ein unbegrenztes Wachstum der Logdateien zu verhindern, werden diese
+automatisch gekürzt. Sobald eine Logdatei mehr als `MAX_LOG_RECORDS`
+Einträge enthält (standardmäßig 1000), bleiben nur die neuesten Datensätze
+erhalten. Die Konstante `MAX_LOG_RECORDS` kann in `Backend/Config.py`
+angepasst werden.
+
 ## Fehlerbehebung
 
 ### Bekannte Probleme


### PR DESCRIPTION
## Summary
- limit stored log entries to prevent unbounded growth
- keep 1000 records by default via `MAX_LOG_RECORDS`
- update README with new log management notes

## Testing
- `pip install -r Backend/install.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfa20af2c83258561dfae78cd515b